### PR TITLE
API-197: Coveralls code coverage  (#48)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,29 @@ jobs:
           java-version: 8
       - name: Maven Package
         run: mvn clean install -Dgpg.skip -Dmaven.javadoc.skip -Dmaven.test.skip
+
       - name: Tests with Coverage
         run: mvn clean test jacoco:report
+
+      - name: Set branch name and PR number
+        id: refs
+        env:
+          BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
+        run: |
+          echo "::set-output name=branch_name::${BRANCH_NAME_OR_REF#refs/heads/}"
+          echo "::set-output name=pr_number::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
+
+      - name: Report to Coveralls
+        env:
+          CI_NAME: Github
+          CI_BUILD_NUMBER: ${{ github.run_id }}
+          CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
+          CI_BRANCH: ${{ steps.refs.outputs.branch_name }}
+          CI_PULL_REQUEST: ${{ steps.refs.outputs.pr_number }}
+        run: |
+          mvn coveralls:report \
+          --no-transfer-progress \
+          -D repoToken=${{ secrets.COVERALLS_TOKEN }}
 
   release:
     needs: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [ push, pull_request ]
+on: [ push, pull_request_target ]
 
 jobs:
 
@@ -14,7 +14,29 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
+
       - name: Maven Package
         run: mvn clean install -Dgpg.skip -Dmaven.javadoc.skip -Dmaven.test.skip
+
       - name: Tests with Coverage
         run: mvn clean test jacoco:report
+
+      - name: Set branch name and PR number
+        id: refs
+        env:
+          BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
+        run: |
+          echo "::set-output name=branch_name::${BRANCH_NAME_OR_REF#refs/heads/}"
+          echo "::set-output name=pr_number::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
+
+      - name: Report to Coveralls
+        env:
+          CI_NAME: Github
+          CI_BUILD_NUMBER: ${{ github.run_id }}
+          CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
+          CI_BRANCH: ${{ steps.refs.outputs.branch_name }}
+          CI_PULL_REQUEST: ${{ steps.refs.outputs.pr_number }}
+        run: |
+          mvn coveralls:report \
+          --no-transfer-progress \
+          -D repoToken=${{ secrets.COVERALLS_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,10 @@
             <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
     </distributionManagement>
 
     <licenses>


### PR DESCRIPTION
* configure pom for OSSRH deployment

* formatting

* release workflow

* tests

* test

* tests

* update repo token for coverage

* badge adition and experiment with tests

* run release on test success

* use latest ubuntu versions

* add workflow badges

* changes for secrets and groupId

* test something out

* syntax error fix

* tweak for testing

* use jdk 8 instead

* prune useless envs

* try auto releasing via autoReleaseAfterClose

* fix java version on release

* run release on publish only

- tested this now so can run release action when we create a release
- test full flow with a new version

* get ready for Bynder master

- update badges
- update pom with Bynder groupId
- prune travis.yml

* suggested changes-1

- bring back normal repository under distribution
- remove maven-gpg-plugin, maven-javadoc-plugin, maven-source-plugin from non-deploy profile
- move nexus-staging-maven-plugin to deploy profile

* test

* revert to BYnder ids after tests

* test

* resolve conflicts

* coveralls in java

* test coveralls branch fix

* Update tests.yml

* Delete manual.yml

* Create regular-pr.yml

* Delete regular-pr.yml

* Update release.yml

* naming and cleanup

* prune jacoco

no longer need jacoco reports

* test something

* generate reports via jacoco

* Update pom.xml

* huge formatting change